### PR TITLE
FIXED-LINTING-ERROR-CI-CHECK

### DIFF
--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -42,5 +42,22 @@ jobs:
         run: yarn add eslint@^8.40.0 eslint-config-next@13.5.6 eslint-plugin-import@^2.29.0 eslint-plugin-prettier@^5.0.1 eslint-plugin-react@^7.29.4 eslint-plugin-unused-imports@^3.0.0 --dev
         working-directory: web-server
 
+      - name: Setup Python 3.11
+        uses: actions/setup-python@v4
+        with:
+          python-version: "3.11"
+
+      - name: Create and activate virtual environment
+        run: |
+          python -m venv venv
+          source venv/bin/activate
+
+      - name: Install pre-commit
+        run: |
+          source venv/bin/activate
+          python -m pip install pre-commit
+
       - name: Run pre-commit hooks
         uses: pre-commit/action@v3.0.1
+        with:
+          extra_args: --all-files


### PR DESCRIPTION
## Linked Issue(s) 

<!-- Link the issues being closed by or related to this PR. For example, you can use Closes #594 if this PR closes issue number 594 -->
Closes #599

## Acceptance Criteria fulfillment

<!-- This will contain the acceptance criteria required by the Pull Request in order to close the issue. This Section can be deleted if no acceptance criteria are provided. -->

- ✅  Task 1

## Proposed changes 

<!-- CHANGELOG -->
<!--
This pull request addresses the failure of the CI check for all-file linting. The issue arose when attempting to run `python -m pip install pre-commit`, which triggered an error because it tried to install Python packages globally into an environment managed by the system package manager. To resolve this, I created a Python virtual environment and installed the required packages within that isolated environment. This approach prevents any conflicts with the system Python and ensures a smooth installation process. 
-->

<!-- END CHANGELOG -->


## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
This change was necessary to maintain a clean development environment and ensure that the CI checks run without errors. If there are any questions or further suggestions regarding this solution, I am open to discussion.


